### PR TITLE
No need to escape for RTM API

### DIFF
--- a/Sources/SKRTMAPI/SKRTMAPI.swift
+++ b/Sources/SKRTMAPI/SKRTMAPI.swift
@@ -153,7 +153,7 @@ public final class SKRTMAPI: RTMDelegate {
             "id": id ?? Date().slackTimestamp,
             "type": "message",
             "channel": channel,
-            "text": message.slackFormatEscaping,
+            "text": message,
             "thread_ts": threadTs,
             "broadcastReply": broadcastReply
         ]


### PR DESCRIPTION
And this block mention for exemple :/ 